### PR TITLE
:sparkles: feat: Implementing the quiz creation endpoint with JWT aut…

### DIFF
--- a/Controllers/QuizController.cs
+++ b/Controllers/QuizController.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using QuizApp.DTOs;
+using QuizApp.Services;
+using System.Security.Claims;
+
+namespace QuizApp.Controllers;
+[Authorize]
+[Route("api/[controller]")]
+[ApiController]
+public class QuizController : ControllerBase
+{
+    private readonly IQuizService _quizService;
+    public QuizController(IQuizService quizService)
+    {
+        _quizService = quizService;
+    }
+    [HttpPost("CreateQuiz")]
+    public async Task<IActionResult> CreateQuiz([FromBody] CreateQuizDTO createQuizDTO)
+    {
+        try
+        {
+            var userIdClaim = User.Claims.FirstOrDefault(c => c.Type == (ClaimTypes.NameIdentifier))?.Value;
+            if (userIdClaim == null || !int.TryParse(userIdClaim, out int userId))
+            {
+                return Unauthorized("User ID not found in claims.");
+            }
+            var result = await _quizService.CreateQuizAsync(createQuizDTO, userId);
+            return Ok(result);
+
+        }catch(Exception ex)
+        {
+            return BadRequest($"Error creating quiz: {ex.Message}");
+        }
+    }
+}

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -41,6 +41,7 @@ public class UserController : ControllerBase
             return StatusCode(500, $"Error registering user: {ex.Message}");
         }
     }
+    [Authorize(Roles = "Admin")]
     [HttpGet("users")]
     public async Task<IActionResult> GetAllUsers()
     {
@@ -81,5 +82,10 @@ public class UserController : ControllerBase
         var userId = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         var userName = User.Identity?.Name;
         return Ok(new { userId, userName });
+    }
+    [HttpGet("ping")]
+    public IActionResult Ping()
+    {
+        return Ok("pong");
     }
 }

--- a/DTOs/CreateQuizDTO.cs
+++ b/DTOs/CreateQuizDTO.cs
@@ -1,0 +1,7 @@
+﻿namespace QuizApp.DTOs;
+
+public class CreateQuizDTO
+{
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+}

--- a/DTOs/QuizDTO.cs
+++ b/DTOs/QuizDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace QuizApp.DTOs;
+
+public class QuizDTO
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using QuizApp.Mappings;
+using QuizApp.Models.Quiz;
 using QuizApp.Models.User;
 
 namespace QuizApp.Data
@@ -12,8 +13,10 @@ namespace QuizApp.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             modelBuilder.ApplyConfiguration(new UserMap());
+            modelBuilder.ApplyConfiguration(new QuizMap());
         }
 
         public DbSet<UserModel> Users { get; set; }
+        public DbSet<QuizModel> Quizzes { get; set; }
     }
 }

--- a/Mappings/QuizMap.cs
+++ b/Mappings/QuizMap.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using QuizApp.Models.Quiz;
+using QuizApp.Models.User;
+
+namespace QuizApp.Mappings;
+
+public class QuizMap : IEntityTypeConfiguration<QuizModel>
+{
+    public void Configure(EntityTypeBuilder<QuizModel> builder)
+    {
+        builder.ToTable("Quizzes");
+
+        builder.HasKey(q => q.Id);
+
+        builder.Property(q => q.Title)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(q => q.Description)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(q => q.CreatedAt)
+            .IsRequired()
+            .HasDefaultValueSql("GETDATE()");
+
+        builder.Property(q => q.UserId)
+            .IsRequired();
+
+        builder.HasOne(q => q.User)
+            .WithMany(u => u.Quizzes)
+            .HasForeignKey(q => q.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Migrations/20250526175713_AddQuizTable.Designer.cs
+++ b/Migrations/20250526175713_AddQuizTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizApp.Data;
 
@@ -11,9 +12,11 @@ using QuizApp.Data;
 namespace QuizApp.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250526175713_AddQuizTable")]
+    partial class AddQuizTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250526175713_AddQuizTable.cs
+++ b/Migrations/20250526175713_AddQuizTable.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QuizApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQuizTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Quizzes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValueSql: "GETDATE()"),
+                    UserId = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Quizzes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Quizzes_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Quizzes_UserId",
+                table: "Quizzes",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Quizzes");
+        }
+    }
+}

--- a/Models/Quiz/QuizModel.cs
+++ b/Models/Quiz/QuizModel.cs
@@ -1,0 +1,15 @@
+﻿using QuizApp.Models.User;
+using System.ComponentModel.DataAnnotations;
+
+namespace QuizApp.Models.Quiz;
+
+public class QuizModel
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+  
+    public int UserId { get; set; }
+    public UserModel? User { get; set; }
+}

--- a/Models/User/UserModel.cs
+++ b/Models/User/UserModel.cs
@@ -1,4 +1,5 @@
 ﻿using QuizApp.Models.Enum;
+using QuizApp.Models.Quiz;
 
 namespace QuizApp.Models.User
 {
@@ -11,5 +12,6 @@ namespace QuizApp.Models.User
         public DateTime DateCreated { get; set; }
         public SexType SexTypes { get; set; }
         public string Role { get; set; } = "User";
+        public ICollection<QuizModel> Quizzes { get; set; } = [];
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -56,6 +56,7 @@ builder.Services.AddSwaggerGen(c =>
     });
 });
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IQuizService, QuizService>();
 
 builder.Services.AddDbContext<AppDbContext>(options =>
 {

--- a/Services/IQuizService.cs
+++ b/Services/IQuizService.cs
@@ -1,0 +1,9 @@
+﻿using QuizApp.DTOs;
+using QuizApp.Models.Quiz;
+
+namespace QuizApp.Services;
+
+public interface IQuizService
+{
+    Task<QuizDTO> CreateQuizAsync(CreateQuizDTO createQuizDto, int userId);
+}

--- a/Services/QuizService.cs
+++ b/Services/QuizService.cs
@@ -1,0 +1,33 @@
+﻿using QuizApp.Data;
+using QuizApp.DTOs;
+using QuizApp.Models.Quiz;
+
+namespace QuizApp.Services;
+
+public class QuizService : IQuizService
+{
+    private readonly AppDbContext _context;
+    public QuizService(AppDbContext context)
+    {
+        _context = context;
+    }
+    public async Task<QuizDTO> CreateQuizAsync(CreateQuizDTO createQuizDto, int userId)
+    {
+        var quiz = new QuizModel()
+        {
+            Title = createQuizDto.Title,
+            Description = createQuizDto.Description,
+            CreatedAt = DateTime.UtcNow,
+            UserId = userId
+        };
+        _context.Quizzes.Add(quiz);
+        await _context.SaveChangesAsync();
+        return new QuizDTO() 
+        { 
+            Id = quiz.Id, 
+            Title = quiz.Title, 
+            Description = quiz.Description,
+            CreatedAt = quiz.CreatedAt 
+        };
+    }
+}


### PR DESCRIPTION
This PR implements the "CreateQuiz" endpoint, allowing authenticated users to create quizzes in the system.
- New endpoint POST com [Authorize]
- Extracts "UserId" from JWT claims
- Creates a new quiz associated with the authenticated user
- Tested using Swagger and cURL with a valid token